### PR TITLE
fix(ci): repair docs deploy + bring docs/API-reference work to master

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'tutorial/**'
       - '!tutorial/README.md'
+      - 'src/**'
   workflow_dispatch:
 permissions:
   contents: write
@@ -28,5 +29,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
+      - run: pip install ".[docs]"
       - run: cd tutorial && mkdocs gh-deploy -b tutorial-gh-pages --force

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -21,7 +21,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: "3.12"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
       - uses: actions/cache@v4
         with:
@@ -29,5 +29,10 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install ".[docs]"
+      # Docs are built with mkdocstrings, which uses griffe's static analysis
+      # (paths: [../src] in mkdocs.yml) and does not import the package. So we
+      # install only the docs tooling and avoid pulling in the heavy runtime
+      # deps (libcellml, myokit, mpi4py, casadi, ...), which lack wheels on
+      # newer Python versions and broke the build.
+      - run: pip install "mkdocs-material>=9.0" "mkdocstrings[python]>=0.24" "black>=22.0.0"
       - run: cd tutorial && mkdocs gh-deploy -b tutorial-gh-pages --force

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ tests/tmp_pyprobe/
 tmp/
 tutorial/interactive/.ipynb_checkpoints/
 tutorial/interactive/generation_and_calibration.py
+tutorial/site/
 user_run_files/plot_param_id_without_autogen.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ dev = [
     "flake8>=4.0.0",
     "mypy>=0.950",
 ]
+docs = [
+    "mkdocs-material>=9.0",
+    "mkdocstrings[python]>=0.24",
+    "black>=22.0.0",  # used by mkdocstrings to format rendered signatures
+]
 
 [tool.pytest.ini_options]
 # Pytest configuration

--- a/src/identifiabilty_analysis/identifiabilityAnalysis.py
+++ b/src/identifiabilty_analysis/identifiabilityAnalysis.py
@@ -46,8 +46,28 @@ import warnings
 warnings.filterwarnings( "ignore", module = "matplotlib/..*" )
 
 class IdentifiabilityAnalysis():
-    """
-    Class for doing identifiability analysis on a 0D model
+    """Identifiability analysis for a 0D model.
+
+    Quantifies how well calibrated parameters can be identified around a best
+    fit. Currently the Laplace approximation is implemented (computing a
+    covariance matrix from the Hessian of the cost); profile likelihood is
+    planned. Requires an existing inner ``param_id`` object (typically
+    ``CVS0DParamID.param_id``); build conveniently with
+    [`init_from_dict`][identifiabilty_analysis.identifiabilityAnalysis.IdentifiabilityAnalysis.init_from_dict].
+
+    Args:
+        model_path: Path to the generated model file.
+        model_type: ``'cellml_only'``, ``'python'`` or ``'casadi_python'``.
+        file_name_prefix: Model name prefix (names the saved result files).
+        DEBUG: Enable debug behaviour.
+        param_id_output_dir: Root output directory.
+        resources_dir: Directory holding input resources.
+        param_id: The inner param-id engine to analyse (required).
+
+    Attributes:
+        mean_Lapalace: Mean (best-fit) parameter vector after Laplace approximation.
+        covariance_matrix_Laplace: Posterior covariance matrix from the Laplace
+            approximation.
     """
     def __init__(self, model_path, model_type, file_name_prefix, DEBUG=False,
                  param_id_output_dir=None, resources_dir=None, param_id=None):
@@ -72,9 +92,14 @@ class IdentifiabilityAnalysis():
 
     @classmethod
     def init_from_dict(cls, inp_data_dict, param_id):
-        """
-        Build IdentifiabilityAnalysis from an inp_data_dict (e.g. user_inputs) plus
-        the inner param_id object from CVS0DParamID.param_id.
+        """Build an `IdentifiabilityAnalysis` from a config dict and a param-id object.
+
+        Args:
+            inp_data_dict: Configuration dict (e.g. user inputs).
+            param_id: The inner param-id engine, e.g. ``CVS0DParamID.param_id``.
+
+        Returns:
+            IdentifiabilityAnalysis: A configured instance.
         """
         arg_options = [
             "model_path", "model_type", "DEBUG", "param_id_output_dir", "resources_dir",
@@ -88,12 +113,20 @@ class IdentifiabilityAnalysis():
         return cls(**kwargs)
 
     def set_best_param_vals(self, best_param_vals):
+        """Supply the best-fit parameter vector to analyse around.
+
+        Args:
+            best_param_vals: Array of best-fit parameter values.
+        """
         self.param_id.set_best_param_vals(best_param_vals)
         self.best_param_vals = best_param_vals
 
     def run(self, ia_options):
-        """
-        Run the identifiability analysis based on the chosen method
+        """Run the identifiability analysis using the chosen method.
+
+        Args:
+            ia_options: Options dict; ``method`` selects ``'Laplace'`` or
+                ``'profile_likelihood'`` (the latter is not yet implemented).
         """
         if ia_options['method'] == 'profile_likelihood':
             self.run_profile_likelihood(ia_options)
@@ -104,12 +137,23 @@ class IdentifiabilityAnalysis():
         return
 
     def run_profile_likelihood(self, ia_options):
+        """Profile-likelihood identifiability analysis (not yet implemented)."""
         # TODO
         print("Profile Likelihood method not yet implemented")
         exit()
         pass
 
     def run_laplace_approximation(self, ia_options):
+        """Run the Laplace approximation around the best fit.
+
+        Computes the Hessian of the cost, inverts it to a covariance matrix
+        (falling back to a regularised/pseudo-inverse if singular), and saves
+        ``{prefix}_laplace_mean.npy`` and ``{prefix}_laplace_covariance.npy``.
+
+        Args:
+            ia_options: Options dict; ``sub_method`` selects the Hessian method
+                (default ``'parabola_fit'``).
+        """
         from param_id.differentiable import assert_mle_cost_for_bayesian
 
         assert_mle_cost_for_bayesian(

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -133,8 +133,60 @@ def _require_casadi():
 
 
 class CVS0DParamID():
-    """
-    Class for doing parameter identification on a 0D cvs model
+    """Parameter identification (calibration) for a 0D CVS model.
+
+    This is the main user-facing entry point for calibration. It wraps an inner
+    optimisation engine ([`OpencorParamID`][param_id.paramID.OpencorParamID], or
+    [`OpencorMCMC`][param_id.paramID.OpencorMCMC] when ``mcmc_instead=True``) and
+    coordinates loading observation data, selecting parameters, running the
+    optimiser, and writing/plotting results. It is MPI-aware: rank 0 handles all
+    file I/O and output directory creation.
+
+    Construct it either directly, or from a config dict with
+    [`init_from_dict`][param_id.paramID.CVS0DParamID.init_from_dict]. A typical
+    flow is::
+
+        pid = CVS0DParamID.init_from_dict(inp)
+        pid.set_ground_truth_data(obs_data_dict)
+        pid.set_params_for_id(params_for_id_dict)
+        pid.set_param_id_method("genetic_algorithm")
+        pid.run()
+        pid.simulate_with_best_param_vals()
+        pid.plot_outputs()
+
+    Args:
+        model_path: Path to the generated model file (CellML/Python/CasADi).
+        model_type: One of ``'cellml_only'``, ``'python'``, ``'casadi_python'``.
+        param_id_method: Optimiser to use, e.g. ``'genetic_algorithm'``,
+            ``'CMA-ES'``, ``'bayesian'``, ``'sp_minimize'``.
+        mcmc_instead: If True, build an MCMC sampler instead of an optimiser.
+        file_name_prefix: Model name prefix; ties together the resource files
+            and names the output case directory.
+        params_for_id_path: Optional path to a ``{prefix}_params_for_id.csv``.
+            Alternatively call
+            [`set_params_for_id`][param_id.paramID.CVS0DParamID.set_params_for_id].
+        param_id_obs_path: Optional path to an ``obs_data.json``. Alternatively
+            call
+            [`set_ground_truth_data`][param_id.paramID.CVS0DParamID.set_ground_truth_data].
+        sim_time: Logged simulation duration (s).
+        pre_time: Unlogged steady-state spin-up duration (s).
+        dt: Output sampling step (s); must be <= every dt in the obs data.
+        solver_info: Solver config dict (defaults to ``{"solver": "CVODE_myokit"}``).
+        mcmc_options: Options dict for MCMC (used when ``mcmc_instead=True``).
+        optimiser_options: Options dict for the optimiser (e.g. ``cost_convergence``,
+            ``max_patience``, ``num_calls_to_function``, ``cost_type``). Sensible
+            defaults are used if omitted.
+        do_ad: Enable automatic differentiation (CasADi backend).
+        DEBUG: Enable debug behaviour and the debug optimiser options.
+        param_id_output_dir: Root directory for results; defaults to
+            ``param_id_output/`` in the repo.
+        resources_dir: Directory holding input resources; defaults to
+            ``resources/`` in the repo.
+        one_rank: If True, skip the MPI barrier (single-rank usage).
+
+    Attributes:
+        output_dir: Directory (under ``param_id_output_dir``) where results and
+            plots for this case are written (rank 0 only).
     """
     def __init__(self, model_path, model_type, param_id_method, mcmc_instead=False, file_name_prefix='no_name',
                  params_for_id_path=None,
@@ -292,6 +344,20 @@ class CVS0DParamID():
 
     @classmethod
     def init_from_dict(cls, inp_data_dict):
+        """Build a `CVS0DParamID` from a configuration dict.
+
+        Only the keys relevant to the constructor are consumed. ``file_prefix``
+        is accepted as an alias for ``file_name_prefix``.
+
+        Args:
+            inp_data_dict: Config dict, e.g. as returned by
+                [`get_default_inp_data_dict`][utilities.utility_funcs.get_default_inp_data_dict]
+                and then mutated in code.
+
+        Returns:
+            CVS0DParamID: A configured instance (observation data and parameters
+            still need to be set unless their paths were in the dict).
+        """
         # Only pass kwargs that exist in inp_data_dict
         arg_options = [
             'model_path', 'model_type', 'param_id_method', 'mcmc_instead',
@@ -310,6 +376,22 @@ class CVS0DParamID():
 
     @classmethod
     def init_from_all_dicts(cls, inp_data_dict, obs_data_dict, params_for_id_dict):
+        """Build a fully configured `CVS0DParamID` in one call.
+
+        Convenience constructor that calls
+        [`init_from_dict`][param_id.paramID.CVS0DParamID.init_from_dict] then sets
+        the ground-truth data and the parameters to identify.
+
+        Args:
+            inp_data_dict: Configuration dict (see `init_from_dict`).
+            obs_data_dict: Observation data dict (see
+                [`ObsDataCreator`][utilities.obs_data_helpers.ObsDataCreator]).
+            params_for_id_dict: List of parameter entries to calibrate (see
+                [`set_params_for_id`][param_id.paramID.CVS0DParamID.set_params_for_id]).
+
+        Returns:
+            CVS0DParamID: A ready-to-run instance.
+        """
         new_object = cls.init_from_dict(inp_data_dict)
         new_object.set_ground_truth_data(obs_data_dict)
         new_object.set_params_for_id(params_for_id_dict)
@@ -321,6 +403,17 @@ class CVS0DParamID():
         self.param_id.temp_test2()
 
     def run(self):
+        """Run the parameter identification.
+
+        Executes the configured optimiser. Ground-truth data and parameters to
+        identify must be set first. On rank 0 the best parameters are written to
+        ``best_param_vals.npy`` and per-experiment full-output dumps
+        (``all_outputs_with_best_param_vals_exp_*.npz``) are written under
+        [`output_dir`][param_id.paramID.CVS0DParamID].
+
+        Raises:
+            ValueError: If observation data or parameters for id are not set.
+        """
         self._check_info_available()
         self.param_id.run()
 
@@ -353,6 +446,7 @@ class CVS0DParamID():
                 pass
 
     def run_mcmc(self):
+        """Run MCMC sampling (requires the instance was built with ``mcmc_instead=True``)."""
         mcmc_object.run()
     
     def _check_info_available(self):
@@ -385,6 +479,19 @@ class CVS0DParamID():
             raise ValueError('Param id info not set')
 
     def simulate_with_best_param_vals(self, reset=True, only_one_exp=-1, return_series=False):
+        """Simulate the model using the best-fit parameters.
+
+        Args:
+            reset: Reset the simulation state before running.
+            only_one_exp: If >= 0, only simulate that experiment index;
+                ``-1`` simulates all experiments.
+            return_series: If True, also return the full time-series arrays.
+
+        Returns:
+            If ``return_series`` is False, the observation dict of computed
+            feature values. If True, a tuple ``(obs_dicts, obs_arrays)`` where
+            ``obs_arrays`` holds the time-series for plotting.
+        """
         if return_series:
             obs_dicts, obs_arrays = self.param_id.simulate_once(reset=reset, only_one_exp=only_one_exp, return_series=return_series)
             self.best_output_calculated = True
@@ -395,6 +502,14 @@ class CVS0DParamID():
             return obs_dict
 
     def update_param_range(self, params_to_update_list_of_lists, mins, maxs):
+        """Update the min/max bounds of a subset of parameters after construction.
+
+        Args:
+            params_to_update_list_of_lists: List of parameter-name groups to
+                update; each must match an existing entry in the param-id info.
+            mins: New lower bound for each group.
+            maxs: New upper bound for each group.
+        """
         for params_to_update_list, min, max in zip(params_to_update_list_of_lists, mins, maxs):
             for JJ, param_name_list in enumerate(self.param_id_info["param_names"]):
                 if param_name_list == params_to_update_list:
@@ -402,6 +517,7 @@ class CVS0DParamID():
                     self.param_id_info["param_maxs"][JJ] = max
 
     def set_output_dir(self, path):
+        """Override the directory where results and plots are written (rank 0 only)."""
         if self.rank != 0:
             return
         self.output_dir = path
@@ -414,26 +530,60 @@ class CVS0DParamID():
     
 
     def add_user_operation_func(self, func):
+        """Register a custom feature-extraction function.
+
+        The function can then be referenced by name in a data item's
+        ``operation`` (its operands map to the function args). Set
+        ``func.series_to_constant = True`` for series->scalar features so that
+        auto-plotting works.
+
+        Args:
+            func: The Python callable to register.
+        """
         self.param_id.add_user_operation_func(func)
-    
+
     def add_user_cost_func(self, func):
+        """Register a custom cost function (referenced via ``cost_type``)."""
         self.param_id.add_user_cost_func(func)
-    
+
     def set_param_names(self, param_names):
+        """Override the list of parameter names."""
         if self.mcmc_instead:
             mcmc_object.set_param_names(param_names)
         else:
             self.param_id.set_param_names(param_names)
-    
+
     def set_optimiser_options(self, optimiser_options):
+        """Set/update the optimiser options dict.
+
+        Args:
+            optimiser_options: e.g. ``cost_convergence``, ``max_patience``,
+                ``num_calls_to_function``, ``cost_type``.
+        """
         self.optimiser_options = optimiser_options
         self.param_id.set_optimiser_options(optimiser_options)
 
     def set_param_id_method(self, param_id_method):
+        """Change the optimiser method.
+
+        Args:
+            param_id_method: e.g. ``'genetic_algorithm'``, ``'CMA-ES'``,
+                ``'bayesian'``, ``'sp_minimize'``.
+        """
         self.param_id_method = param_id_method
         self.param_id.set_param_id_method(param_id_method)
 
     def set_ground_truth_data(self, obs_data_dict):
+        """Set the observation (ground-truth) data to calibrate against.
+
+        Parses the obs-data structure into the internal ground-truth dataframe,
+        protocol info, observation info and prediction info.
+
+        Args:
+            obs_data_dict: Observation data dict, e.g. built with
+                [`ObsDataCreator`][utilities.obs_data_helpers.ObsDataCreator] or
+                loaded from an ``obs_data.json`` file.
+        """
         if self.rank == 0:
             print(f'Setting ground truth data: {obs_data_dict}')
         parsed_data = self.obs_and_param_parser.parse_obs_data_json(
@@ -459,6 +609,15 @@ class CVS0DParamID():
             print(f'Ground truth data set: {self.obs_info}')
     
     def set_params_for_id(self, params_for_id_dict):
+        """Set which parameters to identify and their bounds.
+
+        Args:
+            params_for_id_dict: List of entries of the form
+                ``{vessel_name, param_name, min, max, name_for_plotting}`` (the
+                in-memory equivalent of ``{prefix}_params_for_id.csv``).
+                ``vessel_name`` may be a single name or a list of names to share
+                one calibrated parameter across many vessels.
+        """
         if self.rank == 0:
             print(f'Setting params for id: {params_for_id_dict}')
         self.param_id_info = self.obs_and_param_parser.get_param_id_info_from_entries(params_for_id_dict)
@@ -468,6 +627,12 @@ class CVS0DParamID():
             print(f'Params for id set: {self.param_id_info["param_names"]}')
 
     def set_best_param_vals(self, best_param_vals):
+        """Manually supply the best-fit parameter vector (e.g. from a previous run).
+
+        Args:
+            best_param_vals: Array of parameter values, ordered as
+                [`get_param_names`][param_id.paramID.CVS0DParamID.get_param_names].
+        """
         if self.mcmc_instead:
             mcmc_object.set_best_param_vals(best_param_vals)
         else:
@@ -495,6 +660,7 @@ class CVS0DParamID():
         return None
 
     def plot_outputs(self):
+        """Generate and save calibration result plots (under ``output_dir/plots_param_id``)."""
         if self.rank == 0:
             param_vals = self._resolve_best_param_vals_for_outputs()
             if param_vals is not None and not self.mcmc_instead:
@@ -504,6 +670,12 @@ class CVS0DParamID():
         ParamIDPlotOutputs(self).plot_outputs()
 
     def get_mcmc_samples(self):
+        """Load and post-process the MCMC chain (burn-in + stuck-walker removal).
+
+        Returns:
+            tuple: ``(flat_samples, samples, num_params)``, or None if no chain
+            has been written.
+        """
         mcmc_chain_path = os.path.join(self.output_dir, 'mcmc_chain.npy')
 
         if not os.path.exists(mcmc_chain_path):
@@ -550,7 +722,7 @@ class CVS0DParamID():
         return flat_samples, samples, num_params
 
     def plot_mcmc(self):
-
+        """Generate MCMC trace and corner plots from the saved chain (rank 0)."""
         flat_samples, samples, num_params = self.get_mcmc_samples()
         if self.rank != 0:
             return
@@ -730,45 +902,63 @@ class CVS0DParamID():
         return
 
     def set_bayesian_parameters(self, n_calls, n_initial_points, acq_func, random_state, acq_func_kwargs={}):
+        """Configure the Bayesian optimiser.
+
+        Args:
+            n_calls: Total number of objective evaluations.
+            n_initial_points: Number of random initial points before fitting.
+            acq_func: Acquisition function name (e.g. ``'EI'``, ``'LCB'``).
+            random_state: Seed for reproducibility.
+            acq_func_kwargs: Extra keyword args for the acquisition function.
+        """
         self.param_id.set_bayesian_parameters(n_calls, n_initial_points, acq_func, random_state,
                                               acq_func_kwargs=acq_func_kwargs)
 
     def close_simulation(self):
+        """Release the underlying simulation resources."""
         if self.mcmc_instead:
             mcmc_object.close_simulation()
         else:
             self.param_id.close_simulation()
 
-   
-    
+
+
     def get_best_param_vals(self):
+        """Return the best-fit parameter vector (ndarray), or None if not yet run."""
         if self.mcmc_instead:
             return mcmc_object.best_param_vals
         else:
             return self.param_id.best_param_vals
 
     def get_param_names(self):
+        """Return the list of identified parameter names (order matches the param vector)."""
         if self.mcmc_instead:
             return mcmc_object.param_id_info["param_names"]
         else:
             return self.param_id.param_id_info["param_names"]
 
     def get_param_importance(self):
+        """Return per-parameter importance scores (computed during sensitivity step)."""
         return self.param_id.param_importance
 
     def get_collinearity_idx(self):
+        """Return the collinearity index of the identified parameter set."""
         return self.param_id.collinearity_idx
 
     def get_collinearity_idx_pairs(self):
+        """Return pairwise collinearity indices for the identified parameters."""
         return self.param_id.collinearity_idx_pairs
 
     def get_pred_param_importance(self):
+        """Return parameter importance scores for the prediction quantities."""
         return self.param_id.pred_param_importance
 
     def get_pred_collinearity_idx_pairs(self):
+        """Return pairwise collinearity indices for the prediction quantities."""
         return self.param_id.pred_collinearity_idx_pairs
 
     def remove_params_by_idx(self, param_idxs_to_remove):
+        """Drop parameters from the identification set by index."""
         self.__set_and_save_param_names(idxs_to_ignore=param_idxs_to_remove)
         if self.mcmc_instead:
             mcmc_object.remove_params_by_idx(param_idxs_to_remove)
@@ -776,6 +966,7 @@ class CVS0DParamID():
             self.param_id.remove_params_by_idx(param_idxs_to_remove)
 
     def remove_params_by_name(self, param_names_to_remove):
+        """Drop parameters from the identification set by name."""
         param_idxs_to_remove = []
         if self.mcmc_instead:
             num_params = mcmc_object.num_params

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -54,7 +54,8 @@ try:
 except ImportError:
     corner = None
 import csv
-from datetime import date
+import shutil
+from datetime import date, datetime
 # from skopt import gp_minimize, Optimizer
 from parsers.PrimitiveParsers import CSVFileParser, ObsAndParamDataParser
 from param_id.optimisers import GeneticAlgorithmOptimiser, BayesianOptimiser, CMAESOptimiser, SciPyMinimizeOptimiser
@@ -180,6 +181,9 @@ class CVS0DParamID():
             self.plot_dir = os.path.join(self.output_dir, 'plots_param_id')
             if not os.path.exists(self.plot_dir):
                 os.mkdir(self.plot_dir)
+            # Archive the input files (timestamped) used for this run so the user can
+            # later check exactly what params_for_id / obs_data produced these outputs.
+            self._archive_input_files(params_for_id_path, param_id_obs_path)
         else:
             self.output_dir = None
         
@@ -264,6 +268,27 @@ class CVS0DParamID():
         
         self.best_output_calculated = False
         self.sensitivity_calculated = False
+
+    def _archive_input_files(self, params_for_id_path, param_id_obs_path):
+        """Copy the params_for_id and obs_data input files into the run output_dir.
+
+        A ``_<yymmdd>_<HHMMSS>`` timestamp is inserted before the extension (a single
+        timestamp shared by both files), so a user inspecting ``param_id_output/<case>/``
+        can see exactly which inputs were used for that run. Missing/None paths are
+        skipped; multiple runs into the same case dir accumulate timestamped copies.
+        """
+        if self.output_dir is None:
+            return
+        timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
+        for src in (params_for_id_path, param_id_obs_path):
+            if not src or not os.path.isfile(src):
+                continue
+            base, ext = os.path.splitext(os.path.basename(src))
+            dst = os.path.join(self.output_dir, f"{base}_{timestamp}{ext}")
+            try:
+                shutil.copy2(src, dst)
+            except OSError as e:
+                print(f"Warning: could not archive input file {src} -> {dst}: {e}")
 
     @classmethod
     def init_from_dict(cls, inp_data_dict):

--- a/src/protocol_runners/protocol_runner.py
+++ b/src/protocol_runners/protocol_runner.py
@@ -29,23 +29,24 @@ from protocol_runners.protocol_executor import ProtocolExecutor
 
 
 class ProtocolRunner:
-    """
-    Standalone user-facing class for running CellML model protocols.
+    """Standalone, user-facing runner for model protocols.
 
-    Creates its own SimulationHelper (defaulting to myokit / CVODE) and
-    wraps ProtocolExecutor for the simulation loop.
+    Creates its own [`SimulationHelper`][solver_wrappers.python_solver_helper.SimulationHelper]
+    (defaulting to Myokit / CVODE) and wraps ``ProtocolExecutor`` for the
+    multi-experiment / sub-experiment simulation loop. Useful for re-simulating
+    a model with calibrated parameters outside the param-id loop.
 
-    Parameters
-    ----------
-    model_path : str
-        Path to the CellML model file.
-    inp_data_dict : dict, optional
-        Configuration dict containing at least ``dt`` and ``solver_info``.
-        If None, loaded from ``user_run_files/user_inputs.yaml`` (respecting
-        ``user_inputs_path_override`` if set).
-    solver : str, default 'CVODE_myokit'
-        Solver identifier passed to get_simulation_helper.
-        E.g. ``'CVODE_myokit'``, ``'CVODE_opencor'``.
+    Args:
+        model_path: Path to the model file.
+        inp_data_dict: Configuration dict containing at least ``dt`` and
+            ``solver_info``. If None, loaded from
+            ``user_run_files/user_inputs.yaml`` (respecting
+            ``user_inputs_path_override`` if set).
+        solver: Solver identifier passed to
+            [`get_simulation_helper`][solver_wrappers.get_simulation_helper],
+            e.g. ``'CVODE_myokit'`` or ``'CVODE_opencor'``.
+        model_type: Backend family (``'cellml_only'`` / ``'python'`` /
+            ``'casadi_python'``); falls back to ``inp_data_dict['model_type']``.
     """
 
     def __init__(self, model_path, inp_data_dict=None, solver='CVODE_myokit', model_type=None):
@@ -110,31 +111,23 @@ class ProtocolRunner:
 
     def run_protocols(self, model_path, protocol_info=None,
                       id_param_names=None, id_param_vals=None):
-        """
-        Run the protocol defined by *protocol_info* and return result arrays.
+        """Run the protocol defined by ``protocol_info`` and return result arrays.
 
-        Parameters
-        ----------
-        model_path : str
-            Path to the CellML model.  Kept for API compatibility; the model
-            was loaded at construction time and this argument is not re-used.
-        protocol_info : dict, optional
-            If None, read from ``inp_data_dict['param_id_obs_path']``.
-        id_param_names : list, optional
-            Parameter names for identification (same format as param_id).
-        id_param_vals : array-like, optional
-            Values to apply before each experiment (e.g. calibrated parameters).
+        Args:
+            model_path: Path to the model. Kept for API compatibility; the model
+                was loaded at construction time and this argument is not re-used.
+            protocol_info: Protocol descriptor. If None, read from
+                ``inp_data_dict['param_id_obs_path']``.
+            id_param_names: Parameter names to set (same format as param_id).
+            id_param_vals: Values to apply before each experiment (e.g.
+                calibrated parameters).
 
-        Returns
-        -------
-        t_list : list[np.ndarray]
-            Time vector per experiment with pre_time removed.
-        res_list : list[list[np.ndarray]]
-            Result arrays per experiment.  ``res_list[exp_idx][var_idx]``
-            is the full time-series for that variable, concatenated across
-            all sub-experiments.
-        sim_times : list[list[float]]
-            The sim_times from protocol_info.
+        Returns:
+            tuple: ``(t_list, res_list, sim_times)`` where ``t_list`` is the time
+            vector per experiment (pre_time removed); ``res_list[exp][var]`` is
+            the full time-series for that variable concatenated across
+            sub-experiments; and ``sim_times`` is the ``sim_times`` from
+            ``protocol_info``.
         """
         if protocol_info is None:
             obs_path = self.inp_data_dict['param_id_obs_path']

--- a/src/scripts/script_generate_with_new_architecture.py
+++ b/src/scripts/script_generate_with_new_architecture.py
@@ -51,7 +51,22 @@ def _is_cellml2_model_with_libcellml(model_path):
 
 def generate_with_new_architecture(do_generation_with_fit_parameters=False,
                                    inp_data_dict=None):
+    """Generate a model from the vessel and parameter CSV arrays.
 
+    Reads the vessel/module and parameter CSV arrays referenced by the config
+    and emits a flat model in the configured ``model_type`` (CellML, Python, C++
+    or CasADi) into the generated-models directory.
+
+    Args:
+        do_generation_with_fit_parameters: If True, regenerate using previously
+            fitted parameters instead of the defaults in the parameters CSV.
+        inp_data_dict: Configuration dict (see
+            [`get_default_inp_data_dict`][utilities.utility_funcs.get_default_inp_data_dict]).
+            If None, the values are loaded from ``user_inputs.yaml``.
+
+    Returns:
+        bool: True if generation succeeded, False otherwise.
+    """
     yaml_parser = YamlFileParser()
     inp_data_dict = yaml_parser.parse_user_inputs_file(inp_data_dict, obs_path_needed=False, 
                                                        do_generation_with_fit_parameters=do_generation_with_fit_parameters)

--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -47,8 +47,36 @@ RED = '\033[31m'
 RESET = '\033[0m'
 
 class SensitivityAnalysis():
-    """
-    Class for doing sensitivity analysis on a 0D model
+    """Variance-based (Sobol) global sensitivity analysis for a 0D model.
+
+    Wraps the Sobol SA manager and coordinates loading observation data,
+    selecting parameters, running the analysis, and ranking the most impactful
+    parameters. Construct from a config dict with
+    [`init_from_dict`][sensitivity_analysis.sensitivityAnalysis.SensitivityAnalysis.init_from_dict].
+
+    Typical flow::
+
+        sa = SensitivityAnalysis.init_from_dict(inp)
+        sa.set_ground_truth_data(obs_data_dict)
+        sa.set_params_for_id(params_for_id_dict)
+        sa.run_sensitivity_analysis(sa_options)
+        top = sa.choose_most_impactful_params_sobol(top_n=5, index_type='ST')
+
+    Args:
+        model_path: Path to the generated model file.
+        model_type: ``'cellml_only'``, ``'python'`` or ``'casadi_python'``.
+        file_name_prefix: Model name prefix.
+        sa_options: SA options dict (``method``, ``sample_type``,
+            ``num_samples``, ``output_dir``).
+        DEBUG: Enable debug behaviour.
+        param_id_output_dir: Root output directory.
+        resources_dir: Directory holding input resources.
+        model_out_names: Optional explicit list of model output variable names.
+        solver_info: Solver config dict.
+        dt: Output sampling step (s).
+        optimiser_options: Options dict (used if a nominal calibration is run).
+        param_id_obs_path: Optional path to an ``obs_data.json``.
+        params_for_id_path: Optional path to a ``{prefix}_params_for_id.csv``.
     """
     def __init__(self, model_path, model_type, file_name_prefix, sa_options, DEBUG=False,
                  param_id_output_dir=None, resources_dir=None, model_out_names=[], 
@@ -75,6 +103,17 @@ class SensitivityAnalysis():
 
     @classmethod
     def init_from_dict(cls, inp_data_dict):
+        """Build a `SensitivityAnalysis` from a configuration dict.
+
+        ``file_prefix`` is accepted as an alias for ``file_name_prefix``.
+
+        Args:
+            inp_data_dict: Configuration dict (see
+                [`get_default_inp_data_dict`][utilities.utility_funcs.get_default_inp_data_dict]).
+
+        Returns:
+            SensitivityAnalysis: A configured instance.
+        """
         # parse the user inputs dictionary
         yaml_parser = YamlFileParser()
         inp_data_dict = yaml_parser.parse_user_inputs_file(inp_data_dict)
@@ -100,18 +139,39 @@ class SensitivityAnalysis():
         return sa
 
     def add_user_operation_func(self, func):
+        """Register a custom feature-extraction function (see
+        [`CVS0DParamID.add_user_operation_func`][param_id.paramID.CVS0DParamID.add_user_operation_func])."""
         self.SA_manager.add_user_operation_func(func)
 
     def set_sa_options(self, sa_options):
+        """Set/update the sensitivity-analysis options dict.
+
+        Args:
+            sa_options: e.g. ``method`` (``'sobol'``/``'naive'``),
+                ``sample_type``, ``num_samples``, ``output_dir``.
+        """
         self.SA_manager.set_sa_options(sa_options)
 
     def set_ground_truth_data(self, obs_data_dict):
+        """Set the observation data defining the outputs of interest.
+
+        Args:
+            obs_data_dict: Observation data dict (see
+                [`ObsDataCreator`][utilities.obs_data_helpers.ObsDataCreator]).
+        """
         self.SA_manager.set_ground_truth_data(obs_data_dict)
-        
+
     def set_params_for_id(self, params_for_id_dict):
+        """Set which parameters to vary and their bounds.
+
+        Args:
+            params_for_id_dict: List of parameter entries (see
+                [`CVS0DParamID.set_params_for_id`][param_id.paramID.CVS0DParamID.set_params_for_id]).
+        """
         self.SA_manager.set_params_for_id(params_for_id_dict)
-    
+
     def set_model_out_names(self, obs_data_dict):
+        """Derive and store the model output variable names from the obs data."""
         # TODO fix for arbitrary number of operands
         # mohammad must have done this already.
         self.model_out_names = []
@@ -122,6 +182,13 @@ class SensitivityAnalysis():
             self.model_out_names.append(item["operands"][0])
 
     def run_sensitivity_analysis(self, sa_options=None):
+        """Run the sensitivity analysis, dispatching by ``method``.
+
+        Args:
+            sa_options: Optional options dict; if omitted, the options set at
+                construction (or via ``set_sa_options``) are used. ``method``
+                may be ``'sobol'`` or ``'naive'``.
+        """
         if sa_options is None:
             sa_options = self.sa_options
         else:
@@ -136,7 +203,14 @@ class SensitivityAnalysis():
             exit()
 
     def run_sobol_sensitivity(self, sa_options=None):
+        """Run Sobol SA and (on rank 0) save indices and plots.
 
+        Computes first-order (S1), total (ST) and second-order (S2) Sobol
+        indices. Ground-truth data and parameters for id must be set first.
+
+        Args:
+            sa_options: Optional options dict (see ``set_sa_options``).
+        """
         comm = MPI.COMM_WORLD
         rank = comm.Get_rank()
         output_dir = self.SA_manager.output_dir

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -590,6 +590,30 @@ class sobol_SA():
         create_heatmap(S1_heatmap_data, 'First-Order ($S_1$)')
         create_heatmap(ST_heatmap_data, 'Total-Order ($S_T$)')
 
+    @staticmethod
+    def _uniquify_output_names(labels, ops):
+        """Return labels guaranteed unique so each Sobol output keeps its own
+        column. pandas assigns DataFrame columns by label, so a repeated label
+        would let a later data_item silently overwrite an earlier one and the
+        outputs would collapse to one-per-name (issue #240). Repeated labels are
+        first distinguished by their operation, then by a ' #k' suffix."""
+        counts = {}
+        for lab in labels:
+            counts[lab] = counts.get(lab, 0) + 1
+        stage1 = [
+            f"{lab} [{ops[i]}]" if counts[lab] > 1 and ops[i] else lab
+            for i, lab in enumerate(labels)
+        ]
+        seen, out = {}, []
+        for lab in stage1:
+            if lab in seen:
+                seen[lab] += 1
+                out.append(f"{lab} #{seen[lab]}")
+            else:
+                seen[lab] = 1
+                out.append(lab)
+        return out
+
     def save_sobol_indices(self, S1_all, ST_all, S2_all):
         if self.rank != 0:
             return
@@ -605,18 +629,27 @@ class sobol_SA():
         n_outputs = S1_all.shape[0]
         param_names = self.SA_info["param_names"]
 
-        # Prepare output/feature names
-        if n_outputs <= len(self.obs_info['names_for_plotting']):
-            output_names = [
-                f"{self.obs_info['names_for_plotting'][i]} (Exp{self.obs_info['experiment_idxs'][i]}, Sub{self.obs_info['subexperiment_idxs'][i]})"
-                for i in range(n_outputs)
-            ]
-        else:
-            output_names = [
-                f"{self.obs_info['names_for_plotting'][i]} (Exp{self.obs_info['experiment_idxs'][i]}, Sub{self.obs_info['subexperiment_idxs'][i]})"
-                for i in range(n_outputs-1)
-            ]
-            output_names.append("Cost")
+        # Prepare output/feature names. Two data_items that resolve to the same
+        # (name_for_plotting, experiment, subexperiment) produce identical column
+        # labels; since pandas assigns DataFrame columns by label, the later one
+        # would silently overwrite the earlier and the Sobol output would collapse
+        # to one-per-name (issue #240). Build the labels, then disambiguate any
+        # collisions so every data_item keeps its own column.
+        names = self.obs_info['names_for_plotting']
+        exps = self.obs_info['experiment_idxs']
+        subs = self.obs_info['subexperiment_idxs']
+        ops = self.obs_info.get('operations', [])
+
+        n_named = n_outputs if n_outputs <= len(names) else n_outputs - 1
+        base_labels, base_ops = [], []
+        for i in range(n_named):
+            base_labels.append(f"{names[i]} (Exp{exps[i]}, Sub{subs[i]})")
+            base_ops.append(ops[i] if i < len(ops) else None)
+        if n_outputs > len(names):
+            base_labels.append("Cost")
+            base_ops.append(None)
+
+        output_names = self._uniquify_output_names(base_labels, base_ops)
 
         # --- Save S1/ST indices ---
         df_Sobol = pd.DataFrame({'Parameter': param_names})

--- a/src/solver_wrappers/__init__.py
+++ b/src/solver_wrappers/__init__.py
@@ -30,13 +30,35 @@ except Exception:
 def get_simulation_helper(model_path: str = None, solver: str = None, 
                           model_type: str = None, dt: float = None, sim_time: float = None, 
                           solver_info: dict = None, pre_time: float = 0.0):
-    """
-    Return the appropriate SimulationHelper class based on solver parameter.
+    """Create a `SimulationHelper` for the requested solver.
 
-    - CVODE_opencor: Use OpenCOR solver CVODE for CellML models (default)
-    - CVODE_myokit: Use Myokit CVODE solver for CellML models
-    - solve_ivp: methods (RK45, BDF, etc.): Use Python/SciPy solver for Python models
-    - casadi_integrator: methods (cvodes, idas, collocation, rk): Use CasADi integrator for CasADi Python models
+    Returns the appropriate backend (OpenCOR, Myokit, SciPy, or CasADi) based on
+    ``solver`` and ``model_type``. All backends share the common
+    [`SimulationHelper`][solver_wrappers.python_solver_helper.SimulationHelper]
+    method surface.
+
+    Args:
+        model_path: Path to the generated model file.
+        solver: Solver identifier. One of:
+
+            - ``'CVODE_opencor'``: OpenCOR CVODE for CellML models (default).
+            - ``'CVODE_myokit'``: Myokit CVODE for CellML models.
+            - ``'solve_ivp'``: Python/SciPy solver for ``model_type='python'``
+              (method set via ``solver_info``, e.g. RK45, BDF).
+            - ``'casadi_integrator'``: CasADi integrator for
+              ``model_type='casadi_python'`` (cvodes, idas, collocation, rk).
+        model_type: ``'cellml_only'``, ``'python'`` or ``'casadi_python'``.
+        dt: Output sampling step (s).
+        sim_time: Logged simulation duration (s).
+        solver_info: Solver config dict (e.g. ``MaximumStep``, ``method``).
+        pre_time: Unlogged steady-state spin-up duration (s).
+
+    Returns:
+        SimulationHelper: The backend instance for the requested solver.
+
+    Raises:
+        ValueError: If the solver is unknown or incompatible with ``model_type``.
+        RuntimeError: If the requested backend is not installed.
     """
     # Define valid solver types
     cellml_solvers = ['CVODE_opencor', 'CVODE_myokit']
@@ -87,6 +109,20 @@ def get_simulation_helper(model_path: str = None, solver: str = None,
     return OpenCORSimulationHelper(model_path, dt, sim_time, solver_info, pre_time=pre_time)
 
 def get_simulation_helper_from_inp_data_dict(inp_data_dict):
+    """Create a `SimulationHelper` from a configuration dict.
+
+    Convenience wrapper around
+    [`get_simulation_helper`][solver_wrappers.get_simulation_helper] that reads
+    ``model_path``, ``solver_info`` (and its ``solver``), ``model_type``, ``dt``,
+    ``sim_time`` and ``pre_time`` from the dict.
+
+    Args:
+        inp_data_dict: Configuration dict (see
+            [`get_default_inp_data_dict`][utilities.utility_funcs.get_default_inp_data_dict]).
+
+    Returns:
+        SimulationHelper: The backend instance for the configured solver.
+    """
     return get_simulation_helper(model_path=inp_data_dict["model_path"], solver=inp_data_dict["solver_info"]["solver"], model_type=inp_data_dict["model_type"], dt=inp_data_dict["dt"], sim_time=inp_data_dict["sim_time"], solver_info=inp_data_dict["solver_info"], pre_time=inp_data_dict["pre_time"])
 
 __all__ = [

--- a/src/solver_wrappers/python_solver_helper.py
+++ b/src/solver_wrappers/python_solver_helper.py
@@ -8,14 +8,20 @@ DEBUG = False
 
 
 class SimulationHelper:
-    """
-    SciPy-based solver for libCellML-generated Python modules.
+    """SciPy-based solver for libCellML-generated Python modules.
 
-    Matches the key interface of the OpenCOR SimulationHelper:
-    - run()
-    - update_times(dt, start_time, sim_time, pre_time)
-    - get_results / get_all_results / get_all_variable_names
-    - get_init_param_vals / set_param_vals
+    This implements the common `SimulationHelper` interface that every backend
+    (OpenCOR, Myokit, SciPy, CasADi) shares. Obtain an instance via
+    [`get_simulation_helper`][solver_wrappers.get_simulation_helper] rather than
+    constructing a backend directly. The methods documented here are available on
+    all backends.
+
+    Typical usage::
+
+        sim = get_simulation_helper_from_inp_data_dict(inp)
+        sim.run()
+        t = sim.get_time()
+        y = sim.get_results(["component/var"], flatten=True)
     """
 
     def __init__(self, model_path, dt, sim_time, solver_info=None, pre_time=0.0):
@@ -41,6 +47,15 @@ class SimulationHelper:
         self._last_results_dict = None
 
     def get_time(self, include_pre_time=False):
+        """Return the output time vector.
+
+        Args:
+            include_pre_time: If True, include the unlogged pre-time portion;
+                otherwise return time relative to the end of pre-time.
+
+        Returns:
+            numpy.ndarray: The sampled time points.
+        """
         if include_pre_time:
             return self.tSim
         else:
@@ -98,6 +113,14 @@ class SimulationHelper:
 
     # ---- timing helpers ----
     def update_times(self, dt, start_time, sim_time, pre_time):
+        """Reconfigure the simulation timing.
+
+        Args:
+            dt: Output sampling step (s).
+            start_time: Start time of the simulation (s).
+            sim_time: Logged simulation duration (s).
+            pre_time: Unlogged steady-state spin-up duration (s).
+        """
         self.dt = dt
         self.pre_time = pre_time
         self.sim_time = sim_time
@@ -111,6 +134,15 @@ class SimulationHelper:
 
     # ---- parameter helpers ----
     def get_init_param_vals(self, param_names):
+        """Read the initial values of the named parameters.
+
+        Args:
+            param_names: List of variable names (each entry may itself be a list
+                of names sharing a value).
+
+        Returns:
+            list: Initial value(s) for each requested parameter.
+        """
         vals = []
         for name_or_list in param_names:
             if not isinstance(name_or_list, list):
@@ -128,6 +160,13 @@ class SimulationHelper:
         return vals
 
     def set_param_vals(self, param_names, param_vals):
+        """Set the values of the named parameters.
+
+        Args:
+            param_names: List of variable names (each entry may be a list of
+                names sharing a value).
+            param_vals: Matching list of values to assign.
+        """
         for idx, name_or_list in enumerate(param_names):
             vals = param_vals[idx]
 
@@ -208,6 +247,11 @@ class SimulationHelper:
             self.var_traj[name] = np.asarray(self.var_traj[name])
 
     def run(self):
+        """Run the simulation over the configured time window.
+
+        Returns:
+            bool: True on success, False if integration failed.
+        """
         # integrate
         solve_kwargs = dict(
             method=self.solve_ivp_method,
@@ -270,6 +314,7 @@ class SimulationHelper:
 
     # ---- results ----
     def get_all_variable_names(self):
+        """Return the names of all state and algebraic/constant variables in the model."""
         return list(self.state_name_to_idx.keys()) + list(self.var_name_to_idx.keys())
 
     def _extract(self, name):
@@ -294,6 +339,17 @@ class SimulationHelper:
         raise ValueError(f"variable {name} not found")
 
     def get_results(self, variables_list_of_lists, flatten=False):
+        """Return time-series results for the requested variables.
+
+        Args:
+            variables_list_of_lists: Variable names. Either a flat list of names,
+                or a list of lists to group variables.
+            flatten: If True, flatten the grouped result into a single list.
+
+        Returns:
+            list: One numpy array per requested variable (nested unless
+            ``flatten=True``). Use ``'time'`` to request the time vector.
+        """
         if type(variables_list_of_lists[0]) is not list:
             variables_list_of_lists = [[entry] for entry in variables_list_of_lists]
         results = []
@@ -305,9 +361,18 @@ class SimulationHelper:
         return results
 
     def get_all_results(self, flatten=False):
+        """Return time-series results for every variable in the model."""
         return self.get_results(self.get_all_variable_names(), flatten=flatten)
 
     def get_all_results_dict(self):
+        """Return all results as a dict keyed by variable name.
+
+        Returns:
+            dict: ``{variable_name: numpy.ndarray}`` for every variable.
+
+        Raises:
+            RuntimeError: If the simulation has not been run yet.
+        """
         if self._has_run:
             self._last_results_dict = self._collect_all_results_dict()
             return {name: np.asarray(val).copy() for name, val in self._last_results_dict.items()}
@@ -351,16 +416,19 @@ class SimulationHelper:
         self.model.compute_computed_constants(self.variables)
 
     def reset_and_clear(self, only_one_exp=-1):
+        """Reset the model state to initial conditions, caching the last results."""
         if self._has_run:
             self._last_results_dict = self._collect_all_results_dict()
         self._init_state()
         self._has_run = False
 
     def reset_states(self):
+        """Reset the state variables to their default initial values."""
         self.states = copy.copy(self.default_state_inits)
         self.model.compute_computed_constants(self.variables)
 
     def close_simulation(self):
+        """Release simulation resources (no-op for the SciPy backend)."""
         # no-op for scipy solver
         pass
 

--- a/src/utilities/obs_data_helpers.py
+++ b/src/utilities/obs_data_helpers.py
@@ -10,6 +10,24 @@ import re
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 
 class ObsDataCreator:
+    """Builder for the observation-data structure used by calibration and SA.
+
+    Produces the same structure as an ``obs_data.json`` file, in memory. Add the
+    protocol info first, then one data item per observable, then retrieve the
+    dict with [`get_obs_data_dict`][utilities.obs_data_helpers.ObsDataCreator.get_obs_data_dict]
+    (or write it to disk with ``dump_to_path``)::
+
+        obs = ObsDataCreator()
+        obs.add_protocol_info(pre_times, sim_times, params_to_change)
+        obs.add_data_item(entry)
+        obs_data_dict = obs.get_obs_data_dict()
+
+    The result is consumed by
+    [`CVS0DParamID.set_ground_truth_data`][param_id.paramID.CVS0DParamID.set_ground_truth_data]
+    and
+    [`SensitivityAnalysis.set_ground_truth_data`][sensitivity_analysis.sensitivityAnalysis.SensitivityAnalysis.set_ground_truth_data].
+    """
+
     def __init__(self):
         self.obs_data_dict = {}
         self.obs_data_dict['protocol_info'] = {}

--- a/src/utilities/utility_funcs.py
+++ b/src/utilities/utility_funcs.py
@@ -349,6 +349,22 @@ def hessian_gauss_newton(residual, theta, eps=1e-6):
     return H_gn
 
 def get_default_inp_data_dict(file_prefix, input_param_file, resources_dir):
+    """Build the default configuration dict (equivalent to ``user_inputs.yaml``).
+
+    This is the starting point for driving the pipeline from Python: it returns a
+    config dict pre-populated with the defaults, which you then mutate in code
+    (e.g. ``inp["sim_time"] = 2``) before passing to the generate/simulate/
+    calibrate stages.
+
+    Args:
+        file_prefix: Model name prefix; ties together the ``{prefix}_*`` resource
+            files in ``resources_dir``.
+        input_param_file: Name of the parameters CSV file.
+        resources_dir: Directory holding the input resources.
+
+    Returns:
+        dict: The configuration dict with default values filled in.
+    """
     inp_data_dict = {}
     inp_data_dict['file_prefix'] = file_prefix
     inp_data_dict['input_param_file'] = input_param_file

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -2578,3 +2578,47 @@ def test_parse_obs_data_json_series_std_required_for_npy_paths(tmp_path):
     with pytest.raises(ValueError, match="requires 'std'"):
         parser.parse_obs_data_json(obs_data_dict=obs_data_dict, pre_time=0.0, sim_time=1.0)
 
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_param_id_archives_input_files(resources_dir, temp_output_dir,
+                                       generated_cellml_model_factory, mpi_comm):
+    """CVS0DParamID archives the params_for_id and obs_data inputs into the run
+    output_dir with a _yymmdd_HHMMSS timestamp, so a user can see exactly which
+    inputs produced a run (issue #233)."""
+    import re
+
+    rank = mpi_comm.Get_rank()
+    model_path = generated_cellml_model_factory('3compartment', '3compartment_parameters.csv')
+    params_for_id_path = os.path.join(resources_dir, '3compartment_params_for_id.csv')
+    obs_path = os.path.join(resources_dir, '3compartment_obs_data.json')
+
+    runner = CVS0DParamID.init_from_dict({
+        'model_path': model_path,
+        'model_type': 'cellml_only',
+        'param_id_method': 'genetic_algorithm',
+        'file_name_prefix': '3compartment',
+        'params_for_id_path': params_for_id_path,
+        'param_id_obs_path': obs_path,
+        'resources_dir': resources_dir,
+        'param_id_output_dir': temp_output_dir,
+        'solver_info': {'solver': 'CVODE_myokit', 'MaximumStep': 0.001, 'MaximumNumberOfSteps': 5000},
+        'dt': 0.01, 'sim_time': 2.0, 'pre_time': 20.0, 'DEBUG': False,
+    })
+
+    if rank == 0:
+        out = runner.output_dir
+        files = os.listdir(out)
+        params_copies = [f for f in files
+                         if re.fullmatch(r'3compartment_params_for_id_\d{6}_\d{6}\.csv', f)]
+        obs_copies = [f for f in files
+                      if re.fullmatch(r'3compartment_obs_data_\d{6}_\d{6}\.json', f)]
+        assert params_copies, f"no timestamped params_for_id copy in {out}: {files}"
+        assert obs_copies, f"no timestamped obs_data copy in {out}: {files}"
+        # Archived copies must match the source inputs byte-for-byte.
+        with open(os.path.join(out, params_copies[0])) as fa, open(params_for_id_path) as fb:
+            assert fa.read() == fb.read()
+        with open(os.path.join(out, obs_copies[0])) as fa, open(obs_path) as fb:
+            assert fa.read() == fb.read()

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -4,11 +4,16 @@
 
 For developers adapting the tutorial locally, check that the formatting renders correctly:
 
-1. Install `Material for MkDocs`:
+1. Install the documentation dependencies (Material for MkDocs + mkdocstrings).
+   From the repo root:
 
     ```
-    pip install mkdocs-material
+    pip install -e ".[docs]"
     ```
+
+    (The `docs` extra is declared in `pyproject.toml`. The API reference is built
+    with the `mkdocstrings` plugin, so this is needed for the full site — plain
+    `pip install mkdocs-material` only renders the hand-written pages.)
 
 2. Navigate to the `/tutorial` directory and start the live preview server:
 
@@ -19,8 +24,33 @@ For developers adapting the tutorial locally, check that the formatting renders 
     The site will be accessible at http://localhost:8000/.
     The server automatically rebuilds on save so you can preview changes as you write.
 
+3. Before opening a PR, run a strict build to catch broken links and unresolved
+   API references:
+
+    ```
+    mkdocs build --strict
+    ```
+
+## Documenting the API
+
+The **API Reference** section is generated automatically from the docstrings in
+`src/` via `mkdocstrings`. There is a single source of truth — the docstrings —
+so keep them up to date when you change a public function or class.
+
+- Use **Google-style** docstrings (`Args:` / `Returns:` / `Raises:`), matching
+  the existing style in `src/utilities/obs_data_helpers.py`.
+- The reference pages live under `tutorial/docs/api/` and are mostly
+  `::: module.path.Symbol` directives plus a short intro. To document a new
+  public class/function, add a `:::` line on the appropriate page (and a nav
+  entry in `mkdocs.yml` if you add a new page).
+- `mkdocstrings` reads the source statically (it does not import it), so heavy
+  optional dependencies like OpenCOR/libCellML do not need to be installed to
+  build the docs.
+
 ## Expected outcome
 
 You should be able to browse the tutorial locally and verify links, images, and formatting.
 
-Note: When changes to the `tutorial` directory are merged into the master branch (after a pull request), they are automatically deployed to the website.
+Note: The site is deployed automatically when changes to `tutorial/**` or `src/**`
+are merged into the master branch (so docstring updates also republish the API
+reference).

--- a/tutorial/docs/api/generation.md
+++ b/tutorial/docs/api/generation.md
@@ -1,0 +1,10 @@
+# Model generation
+
+Generate a flat CellML (or Python / C++ / CasADi) model from the vessel and
+parameter CSV arrays referenced by the configuration dict.
+
+::: scripts.script_generate_with_new_architecture.generate_with_new_architecture
+
+## Converting 0D vessels to 1D
+
+::: scripts.convert_0d_to_1d.convert_0d_to_1d

--- a/tutorial/docs/api/identifiability.md
+++ b/tutorial/docs/api/identifiability.md
@@ -1,0 +1,15 @@
+# Identifiability analysis
+
+`IdentifiabilityAnalysis` quantifies how well parameters can be identified
+around a best fit, via the Laplace approximation (profile likelihood is
+planned). It wraps an existing `CVS0DParamID` object.
+
+::: identifiabilty_analysis.identifiabilityAnalysis.IdentifiabilityAnalysis
+    options:
+      members:
+        - init_from_dict
+        - set_best_param_vals
+        - run
+        - run_laplace_approximation
+        - run_profile_likelihood
+        - plot_laplace_results

--- a/tutorial/docs/api/index.md
+++ b/tutorial/docs/api/index.md
@@ -1,0 +1,79 @@
+# API Reference
+
+This section documents the Python API for driving Circulatory Autogen
+programmatically — the same calls used by the
+[interactive tutorial](https://github.com/FinbarArgus/circulatory_autogen/blob/master/tutorial/interactive/generation_and_calibration.py)
+and by external tools such as the CUFLynx GUI.
+
+The reference pages are generated automatically from the docstrings in `src/`,
+so they stay in sync with the code.
+
+## Setup
+
+The package imports are relative to `src/`, so add it to `sys.path` before
+importing (this is what the tutorials do). Everything must run under the
+OpenCOR Python shell.
+
+```python
+import sys
+sys.path.append("/path/to/circulatory_autogen/src")
+
+from utilities.utility_funcs import get_default_inp_data_dict
+```
+
+## Public API at a glance
+
+The entry points below cover the full generate → simulate → calibrate →
+analyse pipeline. Each links to its detailed reference page.
+
+| Task | Entry point | Page |
+|---|---|---|
+| Build the config dict | [`get_default_inp_data_dict`][utilities.utility_funcs.get_default_inp_data_dict] | [Utilities](utilities.md) |
+| Generate a model | [`generate_with_new_architecture`][scripts.script_generate_with_new_architecture.generate_with_new_architecture] | [Model generation](generation.md) |
+| Run a simulation | [`get_simulation_helper`][solver_wrappers.get_simulation_helper] / [`get_simulation_helper_from_inp_data_dict`][solver_wrappers.get_simulation_helper_from_inp_data_dict] | [Simulation](solver-wrappers.md) |
+| Build observation data | [`ObsDataCreator`][utilities.obs_data_helpers.ObsDataCreator] | [Observation data &amp; utilities](utilities.md) |
+| Calibrate parameters | [`CVS0DParamID`][param_id.paramID.CVS0DParamID] | [Parameter identification](param-id.md) |
+| Sensitivity analysis | [`SensitivityAnalysis`][sensitivity_analysis.sensitivityAnalysis.SensitivityAnalysis] | [Sensitivity analysis](sensitivity.md) |
+| Identifiability analysis | [`IdentifiabilityAnalysis`][identifiabilty_analysis.identifiabilityAnalysis.IdentifiabilityAnalysis] | [Identifiability analysis](identifiability.md) |
+| Run protocols standalone | [`ProtocolRunner`][protocol_runners.protocol_runner.ProtocolRunner] | [Protocols](protocols.md) |
+
+## Typical call sequence
+
+```python
+from utilities.utility_funcs import get_default_inp_data_dict
+from scripts.script_generate_with_new_architecture import generate_with_new_architecture
+from solver_wrappers import get_simulation_helper_from_inp_data_dict
+from utilities.obs_data_helpers import ObsDataCreator
+from param_id.paramID import CVS0DParamID
+
+# 1. Configuration (== user_inputs.yaml defaults, then mutate in code)
+inp = get_default_inp_data_dict(file_prefix, input_param_file, resources_dir)
+inp["sim_time"], inp["pre_time"] = 2, 20.0
+
+# 2. Generate the model
+generate_with_new_architecture(inp_data_dict=inp)
+
+# 3. Simulate
+sim = get_simulation_helper_from_inp_data_dict(inp)
+sim.run()
+t, y = sim.get_time(), sim.get_results(variables_to_plot, flatten=True)
+
+# 4. Build observation data
+obs = ObsDataCreator()
+obs.add_protocol_info(pre_times, sim_times, params_to_change)
+obs.add_data_item(entry)
+obs_data_dict = obs.get_obs_data_dict()
+
+# 5. Calibrate
+pid = CVS0DParamID.init_from_dict(inp)
+pid.set_ground_truth_data(obs_data_dict)
+pid.set_params_for_id(params_for_id_dict)
+pid.run()
+pid.simulate_with_best_param_vals()
+pid.plot_outputs()
+```
+
+`params_for_id_dict` is a list of
+`{vessel_name, param_name, min, max, name_for_plotting}` entries (the in-memory
+equivalent of `{prefix}_params_for_id.csv`); `vessel_name` may be a single name
+or a list to share one calibrated parameter across many vessels.

--- a/tutorial/docs/api/internals.md
+++ b/tutorial/docs/api/internals.md
@@ -1,0 +1,29 @@
+# Parsers &amp; generators (internal)
+
+!!! note
+    These classes are internal building blocks used by the public entry points.
+    They are documented for completeness and for advanced workflows, but their
+    interfaces may change between releases. Prefer the entry points on the
+    [Overview](index.md) page where possible.
+
+## Parsers
+
+::: parsers.ModelParsers.CSV0DModelParser
+
+::: parsers.PrimitiveParsers.YamlFileParser
+
+## Generators
+
+::: generators.CVSCellMLGenerator.CVS0DCellMLGenerator
+
+::: generators.PythonGenerator.PythonGenerator
+
+## Protocol execution
+
+::: protocol_runners.protocol_executor.ProtocolExecutor
+
+## Inner param-id engine
+
+::: param_id.paramID.OpencorParamID
+
+::: param_id.paramID.OpencorMCMC

--- a/tutorial/docs/api/param-id.md
+++ b/tutorial/docs/api/param-id.md
@@ -1,0 +1,36 @@
+# Parameter identification
+
+`CVS0DParamID` orchestrates calibration of a 0D CVS model against observation
+data, across the genetic-algorithm, CMA-ES, Bayesian, and `sp_minimize`
+optimisers, plus MCMC sampling.
+
+::: param_id.paramID.CVS0DParamID
+    options:
+      members:
+        - init_from_dict
+        - init_from_all_dicts
+        - set_ground_truth_data
+        - set_params_for_id
+        - set_param_id_method
+        - set_optimiser_options
+        - set_bayesian_parameters
+        - add_user_operation_func
+        - add_user_cost_func
+        - update_param_range
+        - remove_params_by_name
+        - remove_params_by_idx
+        - run
+        - run_mcmc
+        - simulate_with_best_param_vals
+        - plot_outputs
+        - plot_mcmc
+        - get_mcmc_samples
+        - get_best_param_vals
+        - set_best_param_vals
+        - get_param_names
+        - set_param_names
+        - get_param_importance
+        - get_collinearity_idx
+        - get_collinearity_idx_pairs
+        - set_output_dir
+        - close_simulation

--- a/tutorial/docs/api/protocols.md
+++ b/tutorial/docs/api/protocols.md
@@ -1,0 +1,8 @@
+# Protocols
+
+`ProtocolRunner` is the standalone, user-facing class for running a model
+through a multi-experiment / sub-experiment protocol with given parameter
+values — useful for re-simulating with calibrated parameters outside the
+param-id loop.
+
+::: protocol_runners.protocol_runner.ProtocolRunner

--- a/tutorial/docs/api/sensitivity.md
+++ b/tutorial/docs/api/sensitivity.md
@@ -1,0 +1,17 @@
+# Sensitivity analysis
+
+`SensitivityAnalysis` runs variance-based (Sobol) global sensitivity analysis
+over the parameters selected for identification.
+
+::: sensitivity_analysis.sensitivityAnalysis.SensitivityAnalysis
+    options:
+      members:
+        - init_from_dict
+        - set_ground_truth_data
+        - set_params_for_id
+        - set_sa_options
+        - set_model_out_names
+        - add_user_operation_func
+        - run_sensitivity_analysis
+        - run_sobol_sensitivity
+        - choose_most_impactful_params_sobol

--- a/tutorial/docs/api/solver-wrappers.md
+++ b/tutorial/docs/api/solver-wrappers.md
@@ -1,0 +1,19 @@
+# Simulation
+
+Run forward simulations of a generated model. The factory functions return a
+`SimulationHelper` for the configured solver (OpenCOR, Myokit, SciPy, or
+CasADi); all backends share the common method surface documented below.
+
+## Factory functions
+
+::: solver_wrappers.get_simulation_helper
+
+::: solver_wrappers.get_simulation_helper_from_inp_data_dict
+
+## SimulationHelper
+
+The same interface is implemented by every backend. It is documented here on
+the SciPy/Python backend; the OpenCOR, Myokit, and CasADi backends expose the
+same methods.
+
+::: solver_wrappers.python_solver_helper.SimulationHelper

--- a/tutorial/docs/api/utilities.md
+++ b/tutorial/docs/api/utilities.md
@@ -1,0 +1,22 @@
+# Observation data &amp; utilities
+
+## Building observation data
+
+`ObsDataCreator` is the builder for the observation-data structure (the
+in-memory equivalent of an `obs_data.json` file) consumed by
+`CVS0DParamID.set_ground_truth_data` and
+`SensitivityAnalysis.set_ground_truth_data`.
+
+::: utilities.obs_data_helpers.ObsDataCreator
+
+## Configuration and helper functions
+
+::: utilities.utility_funcs.get_default_inp_data_dict
+
+::: utilities.utility_funcs.change_parameter_values_and_save
+
+::: utilities.utility_funcs.calculate_hessian
+
+::: utilities.utility_funcs.latin_hypercube_sample_and_evaluate
+
+::: utilities.utility_funcs.Normalise_class

--- a/tutorial/docs/design-model.md
+++ b/tutorial/docs/design-model.md
@@ -75,7 +75,7 @@ This file has the structure as shown below.
 | variable_name  | Parameter name                                    |
 | units          | Unit in the defined units in CellML's unit file   |
 | value          | Value of parameter                                |
-| data_reference | Reference of the parameter value. Typically in [last_name][date][first_word_of_paper] format for papers.  |
+| data_reference | Reference of the parameter value. Typically in `[last_name][date][first_word_of_paper]` format for papers.  |
 
 The following is an example of a parameter file.
 

--- a/tutorial/docs/sensitivity-analysis.md
+++ b/tutorial/docs/sensitivity-analysis.md
@@ -101,8 +101,14 @@ important notice: this experimental unit must be placed after the unit from whic
 
 ![Example of operation file](images/SensitivityAnalysis_Operationexample.png)
 
--Notice: sometimes will report error similar like ‘obs_series_array_all[JJ] = self.operation_funcs_dict[
-                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
-TypeError: operation_funcs.mean() argument after ** must be a mapping, not float’, please just change ‘**self.obs_info["operation_kwargs"][JJ]’ to ‘**kwargs’.
+-Notice: sometimes will report an error similar to the following:
+
+```
+obs_series_array_all[JJ] = self.operation_funcs_dict[
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+TypeError: operation_funcs.mean() argument after ** must be a mapping, not float
+```
+
+please just change `**self.obs_info["operation_kwargs"][JJ]` to `**kwargs`.
 
 If there is any other issue, please contact Changqing Dong, email: cdon822@aucklanduni.ac.nz. 

--- a/tutorial/mkdocs.yml
+++ b/tutorial/mkdocs.yml
@@ -10,6 +10,22 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [../src]
+          options:
+            docstring_style: google
+            docstring_options:
+              warn_missing_types: false
+            show_source: false
+            show_root_heading: true
+            members_order: source
+            filters: ["!^_"]
+            merge_init_into_class: true
+            separate_signature: true
 nav:
   - Welcome to Circulatory Autogen: index.md
   - Getting Started: getting-started.md
@@ -21,3 +37,13 @@ nav:
   - "Example: 3Compartment Model": example-3compartment-model.md
   - Running on the HPC: running-on-hpc.md
   - Other Useful Features: other-features.md
+  - API Reference:
+      - Overview: api/index.md
+      - Model generation: api/generation.md
+      - Simulation: api/solver-wrappers.md
+      - Parameter identification: api/param-id.md
+      - Sensitivity analysis: api/sensitivity.md
+      - Identifiability analysis: api/identifiability.md
+      - Protocols: api/protocols.md
+      - Observation data &amp; utilities: api/utilities.md
+      - Parsers &amp; generators (internal): api/internals.md


### PR DESCRIPTION
See branch. Fixes docs deploy: install only docs tooling (mkdocs-material, mkdocstrings[python], black) instead of the full package, and pin runner to Python 3.12. libcellml has no wheel for Python 3.14, which broke 'pip install .[docs]'. mkdocstrings uses griffe static analysis so runtime deps are not needed. Branches from devel, so also brings the docs API-reference work to master.