### PR TITLE
benchmarks + FSA: accurate AADC skip reason, AADC multi-observable docs, one-solve FSA cost+gradient

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,8 +21,11 @@ global search vs multi-start L-BFGS-B driven by different gradient backends).
 | `three_compartment` | 3compartment cardiovascular (stiff, 20 s warmup) | no (Myokit/CasADi) | yes (slow, ~20+ min) |
 
 Both benchmarks run on Myokit and CasADi, so neither needs OpenCOR and both run in CI. AADC is
-recorded as a skipped row on the stiff 3compartment benchmark (its fixed-step tape integrators
-are inaccurate/unstable on stiff models).
+recorded as a skipped row on the 3compartment benchmark: its tape cost can only represent
+observables whose operand is a state with a reimplemented op (max/min/mean), so 3compartment's
+algebraic-variable observables (`aortic_root/u`) and its `max_minus_min` are dropped — AADC
+would optimise a reduced cost, not the full one the other methods use. It stays off until it
+can replicate the same cost (upstream issue #258).
 
 The FitzHugh-Nagumo benchmark is also a normal pytest test
 (`tests/test_param_id.py::test_compare_optimisers_on_fitzhugh_nagumo`) — the test and the

--- a/benchmarks/benchmark_specs.py
+++ b/benchmarks/benchmark_specs.py
@@ -267,10 +267,20 @@ def run_three_compartment(base_config, resources_dir, output_dir, generated_mode
         'multi_start (Myokit FSA)': multi_start_fsa,
         'multi_start (CasADi bdf)': multi_start_casadi,
     }
+    # AADC is left off this benchmark: its tape cost can only represent observables whose
+    # operand is a *state* with a reimplemented operation (max/min/mean). On 3compartment 4 of
+    # the 6 observables -- the aortic_root/u features (an algebraic variable, not a state) and
+    # heart/q_lv's max_minus_min -- are dropped from the tape, so AADC would minimise a reduced
+    # 2-of-6-observable cost rather than the same cost the other methods use. The on-tape
+    # damping fix made the gradient exact for the observables it *can* tape, but full-cost
+    # parity needs the algebraic variables recomputed on the tape and max_minus_min supported
+    # (tracked upstream, issue #258). Until then AADC is not comparable here.
     skipped = {
         'multi_start (AADC AD)':
-            'not suitable for stiff models (AADC fixed-step tape integrators are '
-            'inaccurate/unstable here; use CasADi bdf or Myokit FSA)',
+            "AADC's tape cost covers only state-operand observables with a reimplemented op "
+            "(max/min/mean); 3compartment's algebraic-variable observables (aortic_root/u) and "
+            "its max_minus_min are dropped, so AADC would optimise a reduced cost, not the full "
+            "one -- excluded until it can replicate the same cost (upstream issue #258)",
     }
 
     if rank == 0:

--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -831,12 +831,31 @@ class SciPyMinimizeOptimiser(Optimiser):
                         label = names[0] if isinstance(names, (list, tuple)) else str(names)
                         print(f'    {label:<30} p={init_param_vals[i]:.6g}  dJ/dp={init_gradient[i]:.6e}')
 
-                if (self.do_ad):
-                    def gradient_func(q):
+                # Cache the (cost, gradient) at the most recently visited point. L-BFGS-B
+                # evaluates the objective and its gradient at the same parameter vector, and
+                # get_cost_and_gradient returns both from ONE solve (a single augmented CVODES
+                # solve on the Myokit FSA path). So the objective, the jacobian and the progress
+                # callback all reuse that one solve instead of each triggering its own -- on the
+                # FSA path this removes the separate cost solve per point and the callback's
+                # extra cost/gradient solves per iteration.
+                ad_eval_cache = {"key": None, "cost": None, "grad_real": None}
+
+                def _ad_cost_and_grad(q):
+                    q = np.asarray(q, dtype=float)
+                    key = q.tobytes()
+                    if ad_eval_cache["key"] != key:
                         p = self.param_norm_obj.unnormalise(q)
-                        dJ_dp = self.param_id_obj.get_gradient(p)
-                        return dJ_dp * self.param_ranges
+                        cost, grad_real = self.param_id_obj.get_cost_and_gradient(p)
+                        ad_eval_cache["key"] = key
+                        ad_eval_cache["cost"] = float(cost)
+                        ad_eval_cache["grad_real"] = np.asarray(grad_real, dtype=float).flatten()
+                    return ad_eval_cache["cost"], ad_eval_cache["grad_real"]
+
+                if (self.do_ad):
+                    min_cost_fun = lambda q: _ad_cost_and_grad(q)[0]
+                    gradient_func = lambda q: _ad_cost_and_grad(q)[1] * self.param_ranges
                 else:
+                    min_cost_fun = cost_fun
                     gradient_func = lambda q: approx_fprime(q, cost_fun, epsilon=1e-4)
 
                 cost_history_path = os.path.join(self.output_dir, 'best_cost_history.csv')
@@ -865,7 +884,12 @@ class SciPyMinimizeOptimiser(Optimiser):
                     x_norm = np.asarray(x_norm, dtype=float).copy()
                     last_iterate["x_norm"] = x_norm
                     param_vals = self.param_norm_obj.unnormalise(x_norm)
-                    cost_val = float(self.param_id_obj.get_cost(param_vals))
+                    if self.do_ad:
+                        # Reuse the solve L-BFGS-B already did at this iterate (cache hit) rather
+                        # than recomputing the cost -- and, under DEBUG, the gradient too.
+                        cost_val = float(_ad_cost_and_grad(x_norm)[0])
+                    else:
+                        cost_val = float(self.param_id_obj.get_cost(param_vals))
                     last_iterate["cost"] = cost_val
                     # Live progress: one history row per accepted iteration.
                     _append_history(cost_val, x_norm)
@@ -875,14 +899,14 @@ class SciPyMinimizeOptimiser(Optimiser):
                             label = names[0] if isinstance(names, (list, tuple)) else str(names)
                             print(f'    {label:<30} {param_vals[i]:.6g}')
                         if self.do_ad:
-                            grad = np.asarray(self.param_id_obj.get_gradient(param_vals)).flatten()
+                            grad = _ad_cost_and_grad(x_norm)[1]  # cache hit, real-space gradient
                             print(f'    |grad|_inf = {np.max(np.abs(grad)):.6e}')
                     if cost_val <= self.optimiser_options['cost_convergence']:
                         raise StopIteration(f"Cost converged: {cost_val}")
 
                 res = None
                 try:
-                    res = minimize(cost_fun, self.param_norm_obj.normalise(init_param_vals), method='L-BFGS-B',
+                    res = minimize(min_cost_fun, self.param_norm_obj.normalise(init_param_vals), method='L-BFGS-B',
                             bounds=param_ranges_norm, jac=gradient_func, callback=lbfgsb_callback)
                 except StopIteration as e:
                     print(str(e))

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -2336,8 +2336,14 @@ class OpencorParamID():
                              + np.sum(wp != 0) + np.sum(wd != 0))
         return max(int(D), 1)
 
-    def get_jac_cost_fsa(self, param_vals):
+    def get_jac_cost_fsa(self, param_vals, return_cost=False):
         """Gradient dJ/dp via Myokit CVODES forward sensitivity + directional derivative.
+
+        With ``return_cost=True`` this returns ``(cost, grad)`` instead of just ``grad``. The
+        augmented FSA solve already produces the unperturbed operand traces, so the cost J(p)
+        is reconstructed from them with ``get_cost_from_operands`` (cheap arithmetic, no extra
+        solve) -- it is identical to ``get_cost_from_params(p)``. This lets L-BFGS-B get both
+        the value and the gradient from one CVODES solve per point instead of two.
 
         FSA gives S = d(operand_trace)/dp for every eligible parameter. Rather than
         differentiate each observable operation and cost term by hand, we perturb the
@@ -2365,6 +2371,7 @@ class OpencorParamID():
         flat_names = self._fsa_param_names_flat
         grad = np.zeros(n_params)
         denom = float(self._total_weighted_obs_denominator())
+        raw_cost = 0.0  # unperturbed sub-costs, so we can also return J(p) from this same solve
 
         # ---- Eligible params: directional derivative via FSA, summed over (exp, sub) ----
         for exp_idx in range(num_experiments):
@@ -2378,7 +2385,13 @@ class OpencorParamID():
                 subexp_count = base + sub_idx
                 operands = operands_list[subexp_count]
                 if operands is None:
-                    return np.full(n_params, np.nan)
+                    return (np.inf, np.full(n_params, np.nan)) if return_cost \
+                        else np.full(n_params, np.nan)
+                # Unperturbed cost of this sub from the operand traces the solve already gave us
+                # (get_cost_from_operands is the same one get_cost_obs_and_pred_from_params uses,
+                # so raw_cost / denom reproduces get_cost_from_params exactly -- no extra solve).
+                raw_cost += float(self.get_cost_from_operands(
+                    operands, exp_idx=exp_idx, sub_idx=sub_idx))
                 sens_arr = sens_history[sub_idx] if sub_idx < len(sens_history) else None
                 sens = self.sim_helper.get_sensitivities(
                     self._fsa_dependent_names, flat_names, sensitivities=sens_arr)
@@ -2428,7 +2441,13 @@ class OpencorParamID():
                     grad[j] = (base_cost - c_minus) / h
                 else:
                     grad[j] = 0.0
+        if return_cost:
+            return raw_cost / denom, grad
         return grad
+
+    def get_cost_and_jac_fsa(self, param_vals):
+        """(cost, gradient) from a single Myokit CVODES FSA solve. See get_jac_cost_fsa."""
+        return self.get_jac_cost_fsa(param_vals, return_cost=True)
 
     def _perturb_operands_along_sensitivity(self, operands, sens, pname, h):
         """Return a copy of one sub-experiment's operand traces stepped by h along dS/dp.
@@ -2478,6 +2497,19 @@ class OpencorParamID():
             return self.get_jac_cost_fsa(param_vals)
         else:
             raise ValueError(f"Gradient not available for model_type={self.model_type}")
+
+    def get_cost_and_gradient(self, param_vals):
+        """Return ``(cost, gradient)`` in one evaluation.
+
+        L-BFGS-B needs both J(p) and ∇J(p) at every point it visits. For the Myokit CVODES
+        FSA path a single augmented solve yields both, so this avoids the separate cost solve
+        the optimiser would otherwise do. Other backends fall back to separate calls (CasADi's
+        reverse pass and the AADC tape are cheap, so there is little to merge there).
+        """
+        if self.model_type not in ('casadi_python', 'aadc_python') \
+                and self.fsa_gradient_available():
+            return self.get_cost_and_jac_fsa(param_vals)
+        return float(self.get_cost(param_vals)), self.get_gradient(param_vals)
 
     def _aadc_cost_and_grad(self, param_vals):
         """Compute J(p) and ∇J(p) via AADC tape: forward solve + cost on tape, reverse pass.

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -2028,6 +2028,52 @@ def test_3compartment_fsa_longrun_gradient(
     runner.close_simulation()
 
 
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.need_opencor
+def test_3compartment_fsa_cost_and_gradient_combined(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir):
+    """get_cost_and_gradient() returns the same gradient as get_jac_cost_fsa() and a cost that
+    matches get_cost_from_params(), from a SINGLE augmented CVODES solve.
+
+    This is the speedup the L-BFGS-B path relies on: one FSA solve yields both J(p) and dJ/dp
+    (the cost is reconstructed from the operand traces the solve already produced), instead of
+    a separate cost solve. The gradient must be identical (same operand path); the cost must
+    agree to within the integrator noise floor (a wrong normalisation would show a factor, not
+    a ~1e-5 difference).
+    """
+    runner, _ = _build_3compartment_fsa_runner(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir,
+        pre_time=20.0, sim_time=2.0)
+    inner = runner.param_id
+
+    mins = np.asarray(inner.param_id_info['param_mins'], dtype=float)
+    maxs = np.asarray(inner.param_id_info['param_maxs'], dtype=float)
+    p = mins + 0.4 * (maxs - mins)   # arbitrary interior point
+
+    grad_ref = np.asarray(inner.get_jac_cost_fsa(p), dtype=float).ravel()
+    cost_ref = float(inner.get_cost_from_params(p))
+
+    cost_c, grad_c = inner.get_cost_and_gradient(p)
+    cost_c = float(cost_c)
+    grad_c = np.asarray(grad_c, dtype=float).ravel()
+
+    # Gradient is bit-for-bit the same computation as get_jac_cost_fsa.
+    np.testing.assert_allclose(grad_c, grad_ref, rtol=1e-8, atol=1e-12)
+    # Cost agrees with a standalone evaluation to within the integrator noise (< the 1e-3
+    # best-cost consistency-check threshold), NOT off by a normalisation factor.
+    assert abs(cost_c - cost_ref) <= 1e-3 * max(1.0, abs(cost_ref)), (
+        f"combined cost {cost_c:.6e} vs get_cost_from_params {cost_ref:.6e}")
+
+    # get_cost_and_jac_fsa is the FSA-specific entry point behind get_cost_and_gradient.
+    cost_f, grad_f = inner.get_cost_and_jac_fsa(p)
+    np.testing.assert_allclose(np.asarray(grad_f, dtype=float).ravel(), grad_ref,
+                               rtol=1e-8, atol=1e-12)
+    assert abs(float(cost_f) - cost_ref) <= 1e-3 * max(1.0, abs(cost_ref))
+
+    runner.close_simulation()
+
+
 # Ground-truth params the synthetic multi-sub obs was generated at (the model defaults).
 LV_MULTISUB_TRUE = np.array([5.0, 0.2, 0.2, 3.0])   # alpha, beta, delta, gamma
 

--- a/tutorial/docs/parameter-identification.md
+++ b/tutorial/docs/parameter-identification.md
@@ -282,16 +282,29 @@ Before doing calibration, a solver for the model needs to be chosen
     reports how many and which). Tighten `rtol`/`atol` when using FSA so the sensitivities are well
     resolved.
 
-!!! warning "our AADC wrapper is not yet suitable for stiff models"
+!!! warning "our AADC wrapper is not yet suitable for stiff models or multiple observables"
     The AADC tape backend (`model_type: aadc_python`) records a **fixed-step** integrator, which is
     inaccurate or unstable on stiff models — on the 3compartment cardiovascular model its
     fixed-step implicit solve deviates from CVODE by orders of magnitude. Every AADC run now probes
     the first second of dynamics and prints a loud warning if the model is stiff, pointing you at
-    CasADi `bdf` or Myokit CVODES FSA instead. AADC's tape cost also only represents observables
-    whose operand is a **state** (not an algebraic variable), in a **single** experiment; anything
-    else is reported and omitted from the tape gradient. Use AADC only for non-stiff problems for now. 
-    Future work will get it working for stiff models so its advantages for large numbers of parameters 
-    can be used.
+    CasADi `bdf` or Myokit CVODES FSA instead.
+
+    **AADC is also not currently suitable for problems with multiple observables.** Its tape cost
+    can only represent an observable whose operand is a **state** with a reimplemented operation
+    (`max`/`min`/`mean`), in a **single** experiment. Any other observable — one whose operand is an
+    **algebraic variable** (e.g. a pressure or flow computed from the states rather than integrated),
+    an operation the tape does not reimplement (e.g. `max_minus_min`), or a `series`/other data type
+    — is reported and **omitted from the tape cost and gradient**. When several observables are
+    present and any of them can't be taped, AADC silently minimises the **reduced** cost over only
+    the tapeable subset, not the full cost, so the fit is wrong for the omitted observables and its
+    result is not comparable to the other backends. On the 3compartment model, for instance, only 2
+    of the 6 observables are tapeable (the `aortic_root/u` features are algebraic and `heart/q_lv`
+    uses `max_minus_min`), which is why AADC is left off that benchmark until it can reproduce the
+    full cost. Full-cost parity needs the algebraic variables recomputed on the tape from the state
+    trajectory and `max_minus_min` support (tracked upstream). Use AADC only for non-stiff,
+    single-experiment problems whose observables are all state-operand `max`/`min`/`mean` features
+    for now. Future work will get it working for stiff models and general observables so its
+    advantages for large numbers of parameters can be used.
 
     **Multiple sub-experiments / experiments are not yet supported by the AADC wrapper.** The tape
     records one straight-line integration, so a protocol with more than one sub-experiment (or more


### PR DESCRIPTION
## Summary

Three commits refining the optimiser benchmarks and the Myokit CVODES forward-sensitivity (FSA) gradient path, on top of `feat/multi-start-lbfgsb`.

**1. `docs(benchmarks)` — accurate reason AADC is skipped on 3compartment.** The skipped-row reason blamed stiffness / fixed-step accuracy, but with the on-tape damping fix AADC's semi-implicit *gradient* is exact. The real blocker is observable coverage: its tape cost only represents state-operand observables with a reimplemented op (max/min/mean), so 3compartment's algebraic-variable observables (`aortic_root/u`) and its `max_minus_min` are dropped. AADC would minimise a reduced 2-of-6-observable cost, so it stays a skipped row until it can replicate the full cost (upstream issue #258).

**2. `docs(param-id)` — note AADC is not yet suitable for multiple observables.** Expands the AADC limitations admonition: when several observables are present and any can't be taped, AADC silently minimises the reduced cost over the tapeable subset, so the fit is wrong for the omitted observables. Gives the 3compartment example.

**3. `perf(param-id)` — one FSA solve for cost+gradient, and stop the L-BFGS-B callback re-solving.** On the FSA path each L-BFGS-B point paid for two augmented CVODES solves (separate `get_cost` + `get_jac_cost_fsa`), plus the progress callback re-computed the cost (always) and gradient (under DEBUG) each accepted iteration. Now `get_jac_cost_fsa(return_cost=True)` reconstructs `J(p)` from the operand traces the augmented solve already produced (no extra solve); new `get_cost_and_jac_fsa` / backend-agnostic `get_cost_and_gradient`; `sp_minimize` caches `(cost, grad)` per point so objective, jacobian and callback share one solve.

## Verification

- Combined gradient is bit-identical to `get_jac_cost_fsa`; combined cost matches `get_cost_from_params` within the integrator noise floor. Test: `test_3compartment_fsa_cost_and_gradient_combined`.
- FSA sensitivity scope confirmed already minimal: only params_for_id are CVODES independents (3 eligible + 1 FD-fallback on 3compartment), only observed operands are dependents.
- 3compartment benchmark (8 MPI ranks, 5 starts) before/after — identical optimum, FSA wall-clock **2121 s -> 1184 s (1.79x)**:

| method | best cost | before (s) | after (s) |
|---|---|---|---|
| genetic_algorithm | ~2.3e-2 | 621 | 314* |
| CMA-ES | ~3.7e-2 | 69 | 47* |
| multi_start (Myokit FSA) | 2.2557e-2 | 2121 | **1184** |
| multi_start (CasADi bdf) | 2.2753e-2 | 141 | 158* |
| multi_start (AADC AD) | skipped | — | — |

*GA/CMA-ES/CasADi wall-clock varies with machine load and is unaffected (or barely) by this change; FSA is the comparable result. Warmup left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
